### PR TITLE
Fixed all occurences of WheelFormCpAsset

### DIFF
--- a/src/templates/_edit-form.twig
+++ b/src/templates/_edit-form.twig
@@ -2,7 +2,7 @@
 
 {% import "_includes/forms" as formEl %}
 
-{% do view.registerAssetBundle("Wheelform\\assets\\WheelFormCpAsset") %}
+{% do view.registerAssetBundle("Wheelform\\assets\\WheelformCpAsset") %}
 
 {% set title = (form.id is defined ? 'Edit Form'|t : 'New Form'|t) %}
 {% set docsUrl = 'https://github.com/xpertbot/craft-wheelform' %}

--- a/src/templates/_entries.twig
+++ b/src/templates/_entries.twig
@@ -1,7 +1,7 @@
 {% extends '_layouts/cp' %}
 {% set title = "Entries"|t %}
 
-{% do view.registerAssetBundle("Wheelform\\assets\\WheelFormCpAsset") %}
+{% do view.registerAssetBundle("Wheelform\\assets\\WheelformCpAsset") %}
 
 {% set crumbs = [
     { label: 'Wheel Form', url: url('wheelform') },


### PR DESCRIPTION
There was an error when navigating to both the form settings page and the new form page, `ReflectionException: Class Wheelform\assets\WheelFormCpAsset does not exist`. The error was in the template files, instead of `WheelformCpAsset` it was trying to reference `WheelFormCpAsset`.