### PR TITLE
Displaying form entry values / submission in template 

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Current Field types supported are:
             - value
         - entries
             - id
+            - formId
             - fields
                 - name
                 - label
@@ -93,7 +94,6 @@ Current Field types supported are:
                 - label
                 - value
                 - type
-
 
 ## Template Structure
 
@@ -270,38 +270,6 @@ If you want to stick to HTML and not use the variables:
 </form>
 ```
 
-### Displaying existing form submissions
-You can access existing submitted form entries on a form through the `form.entries` property:
-
-```twig
-{% set form = wheelform.form({ id: 1 }) %}
-{% set entries = form.entries %}
-
-<table>
-    <thead>
-        {% for key, fields in entries|first if key == 'fields'  %}
-            <tr>
-                {% for field in fields  %}
-                    <th>{{ field.label }}</th>
-                {% endfor %}
-                <th>Date</th>
-            </tr>
-        {% endfor %}
-    </thead>
-    <tbody>
-        {% for entry in entries %}
-            <tr data-id="{{ entry.id }}">
-                {% for field in entry.fields %}
-                    <td data-id="{{ field.name }}">{{ field.value }}</td>
-                {% endfor %}
-                    <td data-id="date">{{ entry.date|date("m/d/Y") }}</td>
-            </tr>
-        {% endfor %}
-    </tbody>
-</table>
-```
-
-
 ### Redirecting after submit
 
 If you have a ‘redirect’ hidden input, the user will get redirected to it upon successfully sending the email.
@@ -334,6 +302,38 @@ Similar to the flash message, when a contact form is submitted the plugin will s
 {% endif %}
 ```
 You also have available `submission.id`, `submission.formId` and `submission.date`. Note that `form.submission` will be deleted after first read. 
+
+### Displaying existing form submissions
+You can access existing submitted form entries on a form through the `form.entries` property:
+
+```twig
+{% set form = wheelform.form({ id: 1 }) %}
+{% set entries = form.entries %}
+
+<table>
+    <thead>
+        {% for key, fields in entries|first if key == 'fields'  %}
+            <tr>
+                {% for field in fields  %}
+                    <th>{{ field.label }}</th>
+                {% endfor %}
+                <th>Date</th>
+            </tr>
+        {% endfor %}
+    </thead>
+    <tbody>
+        {% for entry in entries %}
+            <tr data-id="{{ entry.id }}">
+                {% for field in entry.fields %}
+                    <td data-id="{{ field.name }}">{{ field.value }}</td>
+                {% endfor %}
+                <td data-id="date">{{ entry.date|date("m/d/Y") }}</td>
+            </tr>
+        {% endfor %}
+    </tbody>
+</table>
+```
+
 
 ### File attachments
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,15 @@ Current Field types supported are:
                 - value
                 - type
             - date
+        - submission
+            - id
+            - formId
+            - fields
+                - name
+                - label
+                - value
+                - type
+
 
 ## Template Structure
 
@@ -310,6 +319,21 @@ When a contact form is submitted, the plugin will set a `notice` or `success` fl
     <p class="message error">{{ craft.app.session.getFlash('error') }}</p>
 {% endif %}
 ```
+
+### Displaying the last/current submission
+Similar to the flash message, when a contact form is submitted the plugin will store the values of the submitted form in the session and make it available (once) through the `form.submission` variable. You can use this in the template (typically in you re-direct page) like this:
+```twig
+{% set submission = form.submission %}
+{% if submission %}
+    <dl>
+        {% for field in submission.fields %}
+            <dt>{{ field.label }}</dt>
+            <dd>{{ field.value }}</dd>
+        {% endfor %}
+    </dl>
+{% endif %}
+```
+You also have available `submission.id`, `submission.formId` and `submission.date`. Note that `form.submission` will be deleted after first read. 
 
 ### File attachments
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,15 @@ Current Field types supported are:
             - containerClass
             - required
             - order
-            - value    
+            - value
+        - entries
+            - id
+            - fields
+                - name
+                - label
+                - value
+                - type
+            - date
 
 ## Template Structure
 
@@ -252,6 +260,38 @@ If you want to stick to HTML and not use the variables:
     <input type="submit" value="Send">
 </form>
 ```
+
+### Displaying existing form submissions
+You can access existing submitted form entries on a form through the `form.entries` property:
+
+```twig
+{% set form = wheelform.form({ id: 1 }) %}
+{% set entries = form.entries %}
+
+<table>
+    <thead>
+        {% for key, fields in entries|first if key == 'fields'  %}
+            <tr>
+                {% for field in fields  %}
+                    <th>{{ field.label }}</th>
+                {% endfor %}
+                <th>Date</th>
+            </tr>
+        {% endfor %}
+    </thead>
+    <tbody>
+        {% for entry in entries %}
+            <tr data-id="{{ entry.id }}">
+                {% for field in entry.fields %}
+                    <td data-id="{{ field.name }}">{{ field.value }}</td>
+                {% endfor %}
+                    <td data-id="date">{{ entry.date|date("m/d/Y") }}</td>
+            </tr>
+        {% endfor %}
+    </tbody>
+</table>
+```
+
 
 ### Redirecting after submit
 

--- a/src/controllers/MessageController.php
+++ b/src/controllers/MessageController.php
@@ -217,6 +217,7 @@ class MessageController extends Controller
             return $this->asJson(['success' => true, 'message' => $settings->success_message]);
         }
 
+        Craft::$app->getSession()->set('messageID', $message->id);
         Craft::$app->getSession()->setNotice($settings->success_message);
         return $this->redirectToPostedUrl($message);
     }

--- a/src/services/FormService.php
+++ b/src/services/FormService.php
@@ -155,6 +155,19 @@ class FormService extends BaseService
         return $entries;
     }
 
+    public function getSubmission() {
+        $message_id = Craft::$app->getSession()->get('messageID');
+        if (!$message_id ) {
+            return NULL;
+        }
+
+        $message = Message::find()->with('field')->where(['id' => $message_id])->one();
+        $submission = $this->getValues($message);
+        // discard after first read
+        Craft::$app->getSession()->remove('messageID');
+        return $submission;
+    }
+
     // Getters
     public function getRecaptcha()
     {
@@ -231,5 +244,22 @@ class FormService extends BaseService
         }
 
         return '';
+    }
+
+    protected function getValues($formEntry) {
+        $values = array(
+            'id' => $formEntry->id,
+            'form_id' => $formEntry->form_id,
+            'date' => $formEntry->dateCreated
+        );
+        foreach ($formEntry->field as $field) {
+            $values['fields'][] = array (
+                'name' => $field->name,
+                'label' => $field->label,
+                'value' => $formEntry->getValueById($field->id)->value,
+                'type' => $field->type
+            );
+        }
+        return $values;
     }
 }

--- a/src/services/FormService.php
+++ b/src/services/FormService.php
@@ -118,6 +118,7 @@ class FormService extends BaseService
         return $this->fields;
     }
 
+    // Getters
     public function getEntries()
     {
         if(! empty($this->entries))
@@ -135,18 +136,7 @@ class FormService extends BaseService
 
         // map fields and values to entries array
         foreach ($query as $entry) {
-            $item = array();
-            $item['id'] = $entry->id;
-            foreach ($entry->field as $field) {
-                $item['fields'][] = array (
-                    'name' => $field->name,
-                    'label' => $field->label,
-                    'value' => $entry->getValueById($field->id)->value,
-                    'type' => $field->type
-                );
-            }
-            $item['date'] = $entry->dateCreated;
-
+            $item = $this->getValues($entry);
             // ignore any empty items
             if (array_key_exists('fields', $item)) {
                 $entries[] = $item;
@@ -168,7 +158,6 @@ class FormService extends BaseService
         return $submission;
     }
 
-    // Getters
     public function getRecaptcha()
     {
         return (bool) $this->instance->recaptcha;

--- a/src/services/FormService.php
+++ b/src/services/FormService.php
@@ -242,7 +242,7 @@ class FormService extends BaseService
             'date' => $formEntry->dateCreated
         );
         foreach ($formEntry->field as $field) {
-            $values['fields'][] = array (
+            $values['fields'][$field->name] = array (
                 'name' => $field->name,
                 'label' => $field->label,
                 'value' => $formEntry->getValueById($field->id)->value,


### PR DESCRIPTION
These changes creates a simple array of form entry values and return it to the template through the `wheelform.form` variable. 

The array can contain either all entries belonging to a form (through `getEntries()`) or the last saved submission (through `getSubmission()`). The latter is passed on from the submit in a session-variable which in turn is deleted when read.

@xpertbot I can't really see how the full Active Record is exposed here, but I'm in no way an expert on these backend features. I guess perhaps `entries` isn't the best naming.... Of course make any changes and improvements needed (or send it back and I'll do my best :-)