### PR TITLE
Expose "From Email" to Event Class

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,7 +375,8 @@ You can also trigger other custom functionality such as gathering custom field v
 
 `Event` class properties:
 * `form_id` - Current ID of form being submitted, This allows developers some way to check what fields are being sent.
-* `subject` - Subject of the currnet form. This can be modified to make it customizable.
+* `fromEmail` - Email this form will be sent from, set in Wheelform Plugin Settings. This can be modified to make it customizable.
+* `subject` - Subject of the current form. This can be modified to make it customizable.
 * `message` - Associative Array of different fields with the values submitted.
 
 Example Plugin to handle these events. [wheelformhelper](https://github.com/xpertbot/wheelformhelper)

--- a/src/Mailer.php
+++ b/src/Mailer.php
@@ -30,13 +30,14 @@ class Mailer extends Component
 
         // Prep the message Variables
         $defaultSubject = $form->name . " - " . Craft::t("wheelform", 'Submission');
-        $from_email = $settings->from_email;
+        $defaultFromEmail = $settings->from_email;
         $mailMessage = new MailMessage();
         $mailer = Craft::$app->getMailer();
         $text = '';
 
         $event = new SendEvent([
             'form_id' => $form->id,
+            'fromEmail' =>$defaultFromEmail,
             'subject' => $defaultSubject,
             'message' => $message,
         ]);
@@ -80,7 +81,7 @@ class Mailer extends Component
 
         $html_body = $this->compileHtmlBody($event->message);
 
-        $mailMessage->setFrom($from_email);
+        $mailMessage->setFrom($event->fromEmail);
         $mailMessage->setSubject($event->subject);
         $mailMessage->setTextBody($text);
         $mailMessage->setHtmlBody($html_body);

--- a/src/events/SendEvent.php
+++ b/src/events/SendEvent.php
@@ -6,6 +6,8 @@ use yii\base\Event;
 class SendEvent extends Event
 {
     public $form_id;
+    
+    public $fromEmail;
 
     public $subject;
 


### PR DESCRIPTION
The goal behind this pull request is to be able to modify the "From Email" through a plugin such as *Wheelform Helper*. The use case would be when a user submits a form with their email address as a form field, you could then apply that field as the "From Email" making replies in an email client much easier.