### PR TITLE
Remove root styling on "ul", in cp-wheelform.css

### DIFF
--- a/src/assets/css/cp-wheelform.css
+++ b/src/assets/css/cp-wheelform.css
@@ -1,8 +1,4 @@
 
-ul {
-  list-style: none;
-  padding: 10px 0px 0px 5px;
-}
 .mt-10 {
   margin-top: 10px; }
 


### PR DESCRIPTION
This rule moves the main CP navigation off when inside the plugin templates.