### PR TITLE
Wrap label in translation function so these can be translated

### DIFF
--- a/src/models/FormField.php
+++ b/src/models/FormField.php
@@ -58,7 +58,7 @@ class FormField extends ActiveRecord
     public function getLabel()
     {
         if (! empty($this->options['label'])) {
-            return $this->options['label'];
+            return \Craft::t('site', $this->options['label']);
         }
         $label = trim(str_replace(['_', '-'], " ", $this->name));
         $label = ucfirst($label);


### PR DESCRIPTION
Make form field labels translatable.
Labels could be translated in twig when the form is build but for example when form error messages are generated these translations are not used.
By wrapping the return value of the getLabel() function the translated label is used across the whole form.