### PR TITLE
Full control over the mail's subject

### DIFF
--- a/src/Mailer.php
+++ b/src/Mailer.php
@@ -51,7 +51,7 @@ class Mailer extends Component
         $this->form = $form;
 
         // Prep the message Variables
-        $defaultSubject = $this->form->name . " - " . Craft::t("wheelform", 'Submission');
+        $defaultSubject = $this->form->name;
         $from_email = $settings->from_email;
         // Grab any "to" emails set in the form settings.
         $to_emails = StringHelper::split($this->form->to_email);


### PR DESCRIPTION
Remove "Submission" from the mail subject or make it optional. Especially when used in different languages or in different applications than a contact form, this is not beneficial. 

A better solution would be to add a subject field to the form, which can also be populated by field values, like `contact form submission from {{name}}`.