### PR TITLE
Corrected a typo in the use statement of Message-model

### DIFF
--- a/src/console/controllers/MessageController.php
+++ b/src/console/controllers/MessageController.php
@@ -3,7 +3,7 @@ namespace wheelform\console\controllers;
 
 use Craft;
 use craft\helpers\DateTimeHelper;
-use wheelform\Models\Message;
+use wheelform\models\Message;
 use yii\console\Controller;
 
 /**


### PR DESCRIPTION
The correct namespace for the `Message` model is `wheelform\models\Message` - with `models` in lower-case. This caused an error when trying to run the console command or the associated cronjob.