### PR TITLE
Handle non-existent method error in migrations

### DIFF
--- a/src/services/FormService.php
+++ b/src/services/FormService.php
@@ -70,7 +70,10 @@ class FormService extends BaseService
 
         $this->submitButton = array_replace_recursive($this->getDefaultSubmitButton(), $this->submitButton);
 
-        $params = Craft::$app->getUrlManager()->getRouteParams();
+        $params = [];
+        if (method_exists(Craft::$app->getUrlManager(), 'getRouteParams')) {
+            $params = Craft::$app->getUrlManager()->getRouteParams();
+        }
 
         if(! empty($params['variables']['values']))
         {


### PR DESCRIPTION
When trying to create an entry with a form through a migration, the following exception was thrown:
Exception: Calling unknown method: yii\web\UrlManager::getRouteParams()

So here is a quick fix to handle this issue.