### PR TITLE
Remove duplicate translation keys

### DIFF
--- a/src/translations/de/wheelform.php
+++ b/src/translations/de/wheelform.php
@@ -51,7 +51,6 @@ return [
     "Save Entries" => "Eingaben speichern",
     "Save Entries to database" => "Einträge in Datenbank speichern",
     "Send Email" => "E-Mail senden",
-    "Settings" => "Einstellungen",
     "Success Flash Message" => "Erfolgsmeldung",
     "Thank You! we will review your submission shortly." => "Danke! Wir werden Ihre Nachricht in Kürze bearbeiten.",
     "The email address that the contact form will send from." => "Kontaktformular sendet von dieser E-Mail-Adresse.",

--- a/src/translations/nl/wheelform.php
+++ b/src/translations/nl/wheelform.php
@@ -51,7 +51,6 @@ return [
     "Save Entries" => "Items opslaan",
     "Save Entries to database" => "Items opslaan in de database",
     "Send Email" => "E-mail versturen",
-    "Settings" => "Instellingen",
     "Success Flash Message" => "Succes flash bericht",
     "Thank You! we will review your submission shortly." => "Bedankt! We bekijken uw inzending zo spoedig mogelijk.",
     "The email address that the contact form will send from." => "Het e-mailadres dat gebruikt wordt om e-mails te verzenden.",


### PR DESCRIPTION
"Settings" was a duplicate key for DE and NL translations.
Now just one is used (line 35 for both languages)