### PR TITLE
Remove duplicate translation key with respect to alphabetical order

### DIFF
--- a/src/translations/de/wheelform.php
+++ b/src/translations/de/wheelform.php
@@ -32,7 +32,6 @@ return [
     "New" => "Neu",
     "Field Name" => "Feld Name",
     "Type" => "Typ",
-	"Settings" => "Einstellungen",
     "Setting" => "Einstellung",
     "Actions" => "Aktionen",
     "Action" => "Aktion",


### PR DESCRIPTION
As per request: https://github.com/xpertbot/craft-wheelform/pull/177

TL;DR: Remove duplicate key with respect to the alphabetical order.
Couldn't reopen the previous PR so opening a new one.