### PR TITLE
Make available fields configurable (#189)

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -12,7 +12,9 @@ use craft\services\Fields;
 use craft\services\UserPermissions;
 use wheelform\extensions\WheelformVariable;
 use wheelform\fields\FormField;
+use wheelform\db\FormField as DbFormField;
 use wheelform\db\Message;
+use wheelform\models\fields\BaseFieldType;
 use wheelform\models\Settings;
 use wheelform\utilities\Tools;
 use wheelform\services\permissions\WheelformPermissions;
@@ -119,7 +121,19 @@ class Plugin extends BasePlugin
         $settings = $this->getSettings();
         $settings->validate();
         $volumeList = Craft::$app->getVolumes()->getAllVolumes();
-        $emptyLabel =  Craft::t("wheelform", '-- Select Volume --');
+
+        $activeRecord = new DbFormField;
+        $fields = [];
+        foreach($activeRecord->getFieldTypeClasses() as $field) {
+            $fieldClass = new $field;
+            if (!($fieldClass instanceof BaseFieldType)) {
+                continue;
+            }
+
+            $fields[$fieldClass->type] = Craft::t("wheelform", $fieldClass->name);
+        }
+
+        $emptyLabel = Craft::t("wheelform", '-- Select Volume --');
         $volumes = [
             '' => $emptyLabel,
         ];
@@ -134,6 +148,7 @@ class Plugin extends BasePlugin
         return Craft::$app->view->renderTemplate('wheelform/_settings', [
             'settings' => $settings,
             'volumes' => $volumes,
+            'fields' => $fields,
         ]);
     }
 }

--- a/src/controllers/BaseController.php
+++ b/src/controllers/BaseController.php
@@ -7,6 +7,7 @@ use wheelform\models\fields\BaseFieldType;
 
 use wheelform\events\RegisterFieldsEvent;
 use wheelform\db\FormField;
+use wheelform\Plugin;
 
 class BaseController extends Controller
 {
@@ -15,6 +16,9 @@ class BaseController extends Controller
 
     protected function getFieldTypes()
     {
+        $plugin = Plugin::getInstance();
+        $settings = $plugin->getSettings();
+
         $activeRecord = new FormField;
         $fields = $activeRecord->getFieldTypeClasses();
 
@@ -27,9 +31,15 @@ class BaseController extends Controller
         $fieldTypes = [];
         foreach($event->fields as $class) {
             $field = new $class;
-            if($field instanceof BaseFieldType) {
-                $fieldTypes[] = $field;
+            if (!($field instanceof BaseFieldType)) {
+                continue;
             }
+
+            if (is_array($settings->disabled_fields) && in_array($field->type, $settings->disabled_fields)) {
+                continue;
+            }
+
+            $fieldTypes[] = $field;
         }
 
         return $fieldTypes;

--- a/src/templates/_settings.twig
+++ b/src/templates/_settings.twig
@@ -101,3 +101,22 @@
     errors: settings.getErrors('recaptcha_secret'),
     required: false,
 }) }}
+
+<div class="field">
+    <div class="heading">
+        <label for="disabled_fields">{{ "Disabled fields"|t('wheelform')}}</label>
+        <div class="instructions">
+            {{ "Select the fields to disable in the form dialog."|t('wheelform') }}
+        </div>
+    </div>
+    <div class="input ltr">
+        {{ forms.checkboxGroup({
+            id: "disabled_fields",
+            name: "disabled_fields",
+            options: fields,
+            values: settings.disabled_fields ?? settings.disabled_fields,
+            errors: settings.getErrors('disabled_fields'),
+            required: false,
+        }) }}
+    </div>
+</div>

--- a/src/translations/de/wheelform.php
+++ b/src/translations/de/wheelform.php
@@ -13,6 +13,7 @@ return [
     "CP Nav Label" => "CP Navigationslabel",
     "Couldn’t save form." => "Formular konnte nicht gespeichert werden.",
     "Date Submitted" => "Versanddatum",
+    "Disabled fields" => "Deaktivierte Felder",
     "Entries" => "Eingaben",
     "Entries View" => "Ansicht der Eingaben",
     "Form ID" => "Formular-ID",
@@ -49,6 +50,7 @@ return [
     "Required" => "Erforderlich",
     "Save Entries" => "Eingaben speichern",
     "Save Entries to database" => "Einträge in Datenbank speichern",
+    "Select the fields to disable in the form dialog." => "Wähle die Felder, die im Formular-Dialog deaktiviert werden.",
     "Send Email" => "E-Mail senden",
     "Settings" => "Einstellungen",
     "Success Flash Message" => "Erfolgsmeldung",
@@ -61,4 +63,5 @@ return [
     "Value" => "Wert",
     "View" => "Ansicht",
     "View Message" => "Nachricht anzeigen",
+    "Unknown disabled field: '{attribute}'" => "Unbekanntes Feld: '{attribute}'",
 ];


### PR DESCRIPTION
Giving the admin/dev the option, to disable unwanted fields:

New Settings:

![Bildschirmfoto 2020-07-05 um 13 16 27](https://user-images.githubusercontent.com/1436383/86530651-06c9a580-bec3-11ea-9aa3-044bf8597600.png)

Or via `config/wheelform.php`:

```
<?php

return [
    'from_email' => getenv('MAIL_ADDRESS_PRIMARY'),
    'from_name' => getenv('MAIL_NAME_PRIMARY'),
    'cp_label' => 'Formulare',
    'success_message' => 'Danke! Wir werden Ihre Nachricht in Kürze bearbeiten.',
    'volume_id' => 2,
    'disabled_fields' => [
        'file',
        'hidden',
        'html',
        'list',
        'number',
    ],
];
```

Result:

![Bildschirmfoto 2020-07-05 um 13 16 14](https://user-images.githubusercontent.com/1436383/86530670-23fe7400-bec3-11ea-9afd-b5f070e20763.png)
