### PR TITLE
added toggle field, made methods public to be accessible in templates

### DIFF
--- a/src/behaviors/FormFieldBehavior.php
+++ b/src/behaviors/FormFieldBehavior.php
@@ -19,6 +19,7 @@ class FormFieldBehavior extends Behavior
     const FILE_SCENARIO = "file";
     const LIST_SCENARIO = "list";
     const HTML_SCENARIO = "html";
+    const TOGGLE_SCENARIO = "toggle";
 
     public function events()
     {
@@ -53,6 +54,7 @@ class FormFieldBehavior extends Behavior
             self::RADIO_SCENARIO => \wheelform\models\fields\Radio::class,
             self::SELECT_SCENARIO => \wheelform\models\fields\Select::class,
             self::HTML_SCENARIO => \wheelform\models\fields\HtmlField::class,
+            self::TOGGLE_SCENARIO => \wheelform\models\fields\ToggleField::class,
         ];
     }
 }

--- a/src/db/FormField.php
+++ b/src/db/FormField.php
@@ -20,6 +20,7 @@ class FormField extends BaseActiveRecord
     const FILE_SCENARIO = "file";
     const LIST_SCENARIO = "list";
     const HTML_SCENARIO = "html";
+    const TOGGLE_SCENARIO = "toggle";
 
     public static function tableName(): String
     {

--- a/src/db/MessageValue.php
+++ b/src/db/MessageValue.php
@@ -31,6 +31,13 @@ class MessageValue extends BaseActiveRecord
             [['message_id', 'field_id'], 'filter', 'filter' => 'intval'],
             ['value', 'required', 'when' => function($model){
                     return (bool)$model->field->required;
+                }, 'message' => Craft::t('wheelform', 'Please check the box'),
+                'on' => [
+                    FormField::TOGGLE_SCENARIO
+                ]
+            ],
+            ['value', 'required', 'when' => function($model){
+                    return (bool)$model->field->required;
                 }, 'message' => $this->field->getLabel().Craft::t('wheelform', ' cannot be blank.')
             ],
             ['value', 'string', 'on' => [
@@ -125,7 +132,10 @@ class MessageValue extends BaseActiveRecord
     public function beforeSave($insert)
     {
         if($this->field->type == FormField::CHECKBOX_SCENARIO && ! empty($this->value)) {
-            $this->value = implode(', ', $this->value);
+            $items = $this->field->options['items'];
+            $this->value = implode(', ', array_map(function($id) use ($items){
+                return $items[(int)$id] ?? null;
+            }, $this->value));
         } elseif (!empty($this->value) && $this->field->type == FormField::LIST_SCENARIO) {
             $this->value = json_encode($this->value);
         }

--- a/src/models/fields/ToggleField.php
+++ b/src/models/fields/ToggleField.php
@@ -1,0 +1,23 @@
+<?php
+namespace wheelform\models\fields;
+
+class ToggleField extends BaseFieldType
+{
+    public $name = "Toggle";
+
+    public $type = "toggle";
+
+    public function getConfig()
+    {
+        return [
+            [
+                'name' => 'display_required_attribute',
+                'type' => 'boolean',
+                'label' => 'Display Required Attribute',
+                'value' => false,
+                'condition' => 'required', // using lodash _.get we can call nested object e.g. options.placeholder
+                'display_side' => 'left',
+            ]
+        ];
+    }
+}

--- a/src/services/FieldService.php
+++ b/src/services/FieldService.php
@@ -66,6 +66,11 @@ class FieldService extends BaseService
         return (bool) $this->required;
     }
 
+    public function hasLabel()
+    {
+        return !empty($this->options->label);
+    }
+
     public function getLabel()
     {
         if(! empty($this->options->label))
@@ -90,6 +95,16 @@ class FieldService extends BaseService
     public function getPlaceholder()
     {
         return (isset($this->options->placeholder) ? $this->options->placeholder : "");
+    }
+
+    public function getExtensions()
+    {
+        return (isset($this->options->extensions) ? $this->options->extensions : "");
+    }
+
+    public function displayRequiredAttribute()
+    {
+        return !empty($this->options->display_required_attribute);
     }
 
     public function getContent()
@@ -204,6 +219,14 @@ class FieldService extends BaseService
                     $html .= '</div>';
                 }
                 break;
+            case "toggle":
+                $args = array_merge($html_default_args, [
+                    'id' => $this->generateId(),
+                    'class' => "wf-field " . $this->fieldClass
+                ]);
+                $html .= Html::label($this->getLabel(), $this->generateId(), ['class' => 'wf-label']);
+                $html .= Html::checkbox($this->name, !empty($this->value), $args);
+                break;
             case "select":
                 if(empty($this->items)) {
                     break;
@@ -281,7 +304,7 @@ class FieldService extends BaseService
         return Template::raw($html);
     }
 
-    protected function generateId()
+    public function generateId()
     {
         return "wf-" . trim(str_replace([' ', '_'], "-", $this->name)) . "-" . $this->order;
     }

--- a/src/services/FieldService.php
+++ b/src/services/FieldService.php
@@ -209,7 +209,7 @@ class FieldService extends BaseService
                 foreach($this->items as $key => $item) {
                     $args = array_merge($html_default_args, [
                         'id' => "wf-checkbox-" . $this->order . '-' . $key,
-                        'value' => $item,
+                        'value' => $key,
                     ]);
                     $html .= '<div class="wf-checkbox">';
                     $html .= Html::checkbox($this->name . '[]', in_array($item, $value), $args);
@@ -222,10 +222,13 @@ class FieldService extends BaseService
             case "toggle":
                 $args = array_merge($html_default_args, [
                     'id' => $this->generateId(),
-                    'class' => "wf-field " . $this->fieldClass
+                    'class' => "wf-field " . $this->fieldClass,
+                    'value' => 'yes'
                 ]);
-                $html .= Html::label($this->getLabel(), $this->generateId(), ['class' => 'wf-label']);
+                $html .= '<div class="wf-toggle">';
                 $html .= Html::checkbox($this->name, !empty($this->value), $args);
+                $html .= Html::label($this->getLabel(), $this->generateId(), ['class' => 'wf-label']);
+                $html .= '</div>';
                 break;
             case "select":
                 if(empty($this->items)) {


### PR DESCRIPTION
Hi,

Thanks for your useful package, seems just what I need for my project, just needed to change a few little things. Here's a PR if that's of any interest.

It adds a Toggle field, I found it's a bit obscure how to do a simple checkbox (for conditions acceptance for example), with the current checkbox field, I feel it's a lot simpler this way, only one label, no items. And checkbox can be kept for array type of values.
It modified the checkbox rendering so it takes the key as value, and mapped those keys with the values before it's saved. So you have the proper values in database (even if the form items are changed afterwards).

Added a few public method in FieldService for easy access in custom templates.

Cheers