### PR TITLE
Give option to override recaptcha siteverify URL on Craft 3 version of plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
 
+## 2.7.3 - 2024-01-17
+### Fix
+- Fixed ability to overwrite Google Recaptcha URL
+
 ## 2.7.2 - 2022-03-17
 ### Fix
 - Undefined error on form.close()

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "xpertbot/craft-wheelform",
     "description": "Craft CMS 3 Form administrator with Database integration",
     "type": "craft-plugin",
-    "version": "2.7.2",
+    "version": "2.7.3",
     "keywords": [
         "craft",
         "cms",

--- a/src/controllers/MessageController.php
+++ b/src/controllers/MessageController.php
@@ -276,6 +276,11 @@ class MessageController extends BaseController
     protected function validateRecaptcha(string $userRes, string $secret)
     {
         $url = "https://www.google.com/recaptcha/api/siteverify";
+
+        if (!empty($this->config['google_recaptcha_url'])) {
+            $url = $this->config['google_recaptcha_url'];
+        }
+
         $ipAddress = $_SERVER['REMOTE_ADDR'];
         if (array_key_exists('HTTP_X_FORWARDED_FOR', $_SERVER)) {
             $ipParts = explode(',', $_SERVER['HTTP_X_FORWARDED_FOR']);


### PR DESCRIPTION
We are still using Craft 3 for one of our clients and we need the ability to add a custom URL in the configuration file.

The fix for this was actioned on the Craft 4 version of this project via [this issue](https://github.com/xpertbot/craft-wheelform/issues/283) and it would be great if the same feature was supported whilst we look into upgrading Craft versions down the line.

Thanks